### PR TITLE
No module named "Detectron2" Bug Fix

### DIFF
--- a/autodistill_detic/detic_model.py
+++ b/autodistill_detic/detic_model.py
@@ -1,10 +1,8 @@
 import os
 from dataclasses import dataclass
-
 import numpy as np
 import supervision as sv
 import torch
-import subprocess
 from autodistill.detection import CaptionOntology, DetectionBaseModel
 
 import argparse
@@ -68,41 +66,12 @@ def load_detic_model(ontology):
 HOME = os.path.expanduser("~")
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-installation_commands = [
-    "mkdir ~/.cache/autodistill/",
-    "cd ~/.cache/autodistill/",
-    "git clone git@github.com:facebookresearch/detectron2.git",
-    "cd detectron2",
-    "pip install -e .",
-    "pip install -r requirements.txt",
-    "cd ..",
-    "git clone https://github.com/facebookresearch/Detic.git --recurse-submodules",
-    "cd Detic",
-    "pip install -r requirements.txt",
-    "mkdir models",
-    "wget https://dl.fbaipublicfiles.com/detic/Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size.pth -O models/Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size.pth"
-]
-
-def install_detic():
-    for command in installation_commands:
-        # keep track of pathi
-        if command.startswith("cd"):
-            # re[place ~ with home]
-            command = command.replace("~", HOME)
-            os.chdir(command.split(" ")[1])
-
-        subprocess.run(command, shell=True)
-
-
 @dataclass
 class DETIC(DetectionBaseModel):
     ontology: CaptionOntology
 
     def __init__(self, ontology: CaptionOntology):
         self.ontology = ontology
-        if not os.path.exists(HOME + "/.cache/autodistill/detectron2"):
-            install_detic()
-
         original_dir = os.getcwd()
 
         sys.path.insert(0, HOME + "/.cache/autodistill/Detic/third_party/CenterNet2/")

--- a/setup.py
+++ b/setup.py
@@ -6,28 +6,26 @@ import subprocess
 
 with open("./autodistill_detic/__init__.py", 'r') as f:
     content = f.read()
-    # from https://www.py4u.net/discuss/139845
     version = re.search(r'__version__\s*=\s*[\'"]([^\'"]*)[\'"]', content).group(1)
-    
+
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 class AutodistillDetic(install):
     def run(self):
         install.run(self)
-        installation_commands = [
-            "mkdir ~/.cache/autodistill/",
-            "cd ~/.cache/autodistill/",
-            "pip install 'git+https://github.com/facebookresearch/detectron2.git'",
-            "git clone https://github.com/facebookresearch/Detic.git --recurse-submodules",
-            "cd Detic",
-            "pip install -r requirements.txt",
-            "mkdir models",
-            "wget https://dl.fbaipublicfiles.com/detic/Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size.pth -O models/Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size.pth"
-        ]
+        installation_commands = """
+            mkdir -p ~/.cache/autodistill/ &&
+            cd ~/.cache/autodistill/ &&
+            pip install 'git+https://github.com/facebookresearch/detectron2.git' &&
+            git clone https://github.com/facebookresearch/Detic.git --recurse-submodules &&
+            cd Detic &&
+            pip install -r requirements.txt &&
+            mkdir models &&
+            wget https://dl.fbaipublicfiles.com/detic/Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size.pth -O models/Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size.pth
+        """
 
-        for command in installation_commands:
-            subprocess.run(command, shell=True)
+        subprocess.run(installation_commands, shell=True, executable="/bin/bash")
 
 
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setuptools.setup(
         "torch",
         "supervision",
         "numpy",
+        "autodistill",
     ],
     cmdclass={
         'install': AutodistillDetic,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 import setuptools
 from setuptools import find_packages
+from setuptools.command.install import install
 import re
+import subprocess
 
 with open("./autodistill_detic/__init__.py", 'r') as f:
     content = f.read()
@@ -9,6 +11,24 @@ with open("./autodistill_detic/__init__.py", 'r') as f:
     
 with open("README.md", "r") as fh:
     long_description = fh.read()
+
+class AutodistillDetic(install):
+    def run(self):
+        install.run(self)
+        installation_commands = [
+            "mkdir ~/.cache/autodistill/",
+            "cd ~/.cache/autodistill/",
+            "pip install 'git+https://github.com/facebookresearch/detectron2.git'",
+            "git clone https://github.com/facebookresearch/Detic.git --recurse-submodules",
+            "cd Detic",
+            "pip install -r requirements.txt",
+            "mkdir models",
+            "wget https://dl.fbaipublicfiles.com/detic/Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size.pth -O models/Detic_LCOCOI21k_CLIP_SwinB_896b32_4x_ft4x_max-size.pth"
+        ]
+
+        for command in installation_commands:
+            subprocess.run(command, shell=True)
+
 
 setuptools.setup(
     name="autodistill_detic",
@@ -19,11 +39,14 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/autodistill/autodistill-detic",
-    nstall_requires=[
+    install_requires=[
         "torch",
         "supervision",
         "numpy",
     ],
+    cmdclass={
+        'install': AutodistillDetic,
+    },
     packages=find_packages(exclude=("tests",)),
     extras_require={
         "dev": ["flake8", "black==22.3.0", "isort", "twine", "pytest", "wheel"],


### PR DESCRIPTION
## Changes made

In `setup.py` added CustomInstall class `AutodistillDetic` for installing dependencies when building. Some minor typo error.  Install_detic() function is not removed or modified in the `detic_model.py`

## Tests

Ran in google colab with `pip install . ` and in conda environment in Mac with `pip install . ` and compared the result with `pip3 install autodistill-detic` in different conda environment. 

`pip3 install autodistill-detic` returns error such as "no module named supervision, autodistill, or detectron2"

With new modified setup.py using `pip install . `, the errors are fixed. 

Please test for further potential errors. 